### PR TITLE
ユーザー詳細ページの実装

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,6 @@
 class PrototypesController < ApplicationController
   before_action :move_to_index, except: :index
+  before_action :authenticate_user!, except: [:index, :show]
   
   def index
     @prototypes = Prototype.all

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,7 +1,8 @@
 class PrototypesController < ApplicationController
-  before_action :move_to_index, except: :index
+  before_action :set_prototype, except: [:index, :new, :create]
   before_action :authenticate_user!, except: [:index, :show]
-  
+  before_action :contributor_confirmation, only: :edit
+
   def index
     @prototypes = Prototype.all
   end
@@ -49,10 +50,14 @@ class PrototypesController < ApplicationController
 
   private
   def prototype_params
-    params.require(:prototype).permit(:title, :catch_copy, :concept, :image, :user).merge(user_id: current_user.id)
+    params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)
   end
 
-  def move_to_index
-    redirect_to action: :index unless user_signed_in?
+  def set_prototype
+    @prototype = Prototype.find(params[:id])
+  end
+
+  def contributor_confirmation
+    redirect_to root_path unless current_user == @prototype.user
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,5 @@
 class UsersController < ApplicationController
+  def show
+    
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,5 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
-    @name = current_user.name
-    @profile = current_user.profile
-    @occupation = current_user.occupation
-    @position = current_user.position
-    @prototypes = current_user.prototypes
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,2 @@
+class UsersController < ApplicationController
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,10 @@
 class UsersController < ApplicationController
   def show
-    
+    @user = User.find(params[:id])
+    @name = current_user.name
+    @profile = current_user.profile
+    @occupation = current_user.occupation
+    @position = current_user.position
+    @prototypes = current_user.prototypes
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -5,6 +5,6 @@
     <p class="card__summary">
       <%= prototype.catch_copy %>
     </p>
-    <%= link_to prototype.user.name, user_path(current_user.id), class: :card__user %>
+    <%= link_to "by #{prototype.user.name}", user_path(prototype.user), class: :card__user %>
   </div>
 </div>

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -5,6 +5,6 @@
     <p class="card__summary">
       <%= prototype.catch_copy %>
     </p>
-    <%= link_to prototype.user.name, prototype_path(prototype), class: :card__user %>
+    <%= link_to prototype.user.name, user_path(current_user.id), class: :card__user %>
   </div>
 </div>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -4,7 +4,7 @@
       <%# ログインしているときは以下を表示する %>
       <div class="greeting">
         <%= "こんにちは、" %>
-        <%= link_to "#{current_user.name}さん", root_path, class: :greeting__link%>
+        <%= link_to "#{current_user.name}さん", user_path(current_user.id), class: :greeting__link%>
       </div>
        <%# // ログインしているときは上記を表示する %>
     <% end %>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -4,7 +4,7 @@
       <p class="prototype__hedding">
         <%= @prototype.title %>
       </p>
-      <%= link_to @prototype.user.name, root_path, class: :prototype__user %>
+      <%= link_to @prototype.user.name, user_path(current_user.id), class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
       <% if user_signed_in? && current_user.id == @prototype.user_id %>
         <div class="prototype__manage">
@@ -45,14 +45,14 @@
           <%# // ログインしているユーザーには上記を表示する %>
         <% end %>
         <ul class="comments_lists">
-          <% @comments.each do |comment| %>
             <%# 投稿に紐づくコメントを一覧する処理を記述する %>
-            <li class="comments_list">
-              <%= comment.text %>
-              <%= link_to @prototype.user.name, root_path, class: :comment_user %>
-            </li>
+            <% @comments.each do |comment| %>
+              <li class="comments_list">
+                <%= comment.text %>
+                <%= link_to "（#{comment.user.name}）", user_path(current_user.id), class: :comment_user %>
+              </li>
+            <% end %>
             <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
-          <% end %>
         </ul>
       </div>
     </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -4,7 +4,7 @@
       <p class="prototype__hedding">
         <%= @prototype.title %>
       </p>
-      <%= link_to @prototype.user.name, user_path(current_user.id), class: :prototype__user %>
+      <%= link_to @prototype.user.name, user_path(@prototype.user), class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
       <% if user_signed_in? && current_user.id == @prototype.user_id %>
         <div class="prototype__manage">
@@ -49,7 +49,7 @@
             <% @comments.each do |comment| %>
               <li class="comments_list">
                 <%= comment.text %>
-                <%= link_to "（#{comment.user.name}）", user_path(current_user.id), class: :comment_user %>
+                <%= link_to "（#{comment.user.name}）", user_path(comment.user), class: :comment_user %>
               </li>
             <% end %>
             <%# // 投稿に紐づくコメントを一覧する処理を記述する %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,35 @@
+<div class="main">
+  <div class="inner">
+    <div class="user__wrapper">
+      <h2 class="page-heading">
+        <%= "ユーザー名さんの情報"%>
+      </h2>
+      <table class="table">
+        <tbody>
+          <tr>
+            <th class="table__col1">名前</th>
+            <td class="table__col2"><%= "ユーザー名" %></td>
+          </tr>
+          <tr>
+            <th class="table__col1">プロフィール</th>
+            <td class="table__col2"><%= "ユーザーのプロフィール" %></td>
+          </tr>
+          <tr>
+            <th class="table__col1">所属</th>
+            <td class="table__col2"><%= "ユーザーの所属" %></td>
+          </tr>
+          <tr>
+            <th class="table__col1">役職</th>
+            <td class="table__col2"><%= "ユーザーの役職" %></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2 class="page-heading">
+        <%= "ユーザー名さんのプロトタイプ"%>
+      </h2>
+      <div class="user__card">
+        <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,33 +2,34 @@
   <div class="inner">
     <div class="user__wrapper">
       <h2 class="page-heading">
-        <%= "ユーザー名さんの情報"%>
+        <%= "#{@name}さんの情報"%>
       </h2>
       <table class="table">
         <tbody>
           <tr>
             <th class="table__col1">名前</th>
-            <td class="table__col2"><%= "ユーザー名" %></td>
+            <td class="table__col2"><%= @name %></td>
           </tr>
           <tr>
             <th class="table__col1">プロフィール</th>
-            <td class="table__col2"><%= "ユーザーのプロフィール" %></td>
+            <td class="table__col2"><%= @profile %></td>
           </tr>
           <tr>
             <th class="table__col1">所属</th>
-            <td class="table__col2"><%= "ユーザーの所属" %></td>
+            <td class="table__col2"><%= @occupation %></td>
           </tr>
           <tr>
             <th class="table__col1">役職</th>
-            <td class="table__col2"><%= "ユーザーの役職" %></td>
+            <td class="table__col2"><%= @position %></td>
           </tr>
         </tbody>
       </table>
       <h2 class="page-heading">
-        <%= "ユーザー名さんのプロトタイプ"%>
+        <%= "#{@name}さんのプロトタイプ" %>
       </h2>
       <div class="user__card">
         <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+        <%= render partial: "/prototypes/prototype" , collection: @user.prototypes %>
       </div>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,25 +2,25 @@
   <div class="inner">
     <div class="user__wrapper">
       <h2 class="page-heading">
-        <%= "#{@name}さんの情報"%>
+        <%= "#{@user.name}さんの情報"%>
       </h2>
       <table class="table">
         <tbody>
           <tr>
             <th class="table__col1">名前</th>
-            <td class="table__col2"><%= @name %></td>
+            <td class="table__col2"><%= @user.name %></td>
           </tr>
           <tr>
             <th class="table__col1">プロフィール</th>
-            <td class="table__col2"><%= @profile %></td>
+            <td class="table__col2"><%= @user.profile %></td>
           </tr>
           <tr>
             <th class="table__col1">所属</th>
-            <td class="table__col2"><%= @occupation %></td>
+            <td class="table__col2"><%= @user.occupation %></td>
           </tr>
           <tr>
             <th class="table__col1">役職</th>
-            <td class="table__col2"><%= @position %></td>
+            <td class="table__col2"><%= @user.position %></td>
           </tr>
         </tbody>
       </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   resources :prototypes, only: [:index, :new, :create, :show, :destroy, :edit, :update] do
     resources :comments, only: :create
   end
+  resources :users, only: :show
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#What
ここのユーザーの詳細とそのユーザーの投稿内容をページに表示させています！
また未ログイン状態、他ユーザーでは編集や削除が出来ず、ログイン画面にリダレクトする設定にしてあります！

#Why
自分の投稿を他のユーザーに勝手に書き換えられないためです！